### PR TITLE
Fix: Validating string doesn't allow empty string if defaultValue is empty

### DIFF
--- a/azure/batch_extensions/_template_utils.py
+++ b/azure/batch_extensions/_template_utils.py
@@ -59,7 +59,7 @@ def _validate_string(value, content):
     :param dict content: The template parameter definition.
     :returns: str
     """
-    if value in [None, ""]:
+    if value in [None, ""] and content['defaultValue'] != "":
         raise TypeError("Empty string value is invalid: {}".format(value))
 
     value = value if isinstance(value, _UNICODE_TYPE) else str(value)

--- a/azure/batch_extensions/_template_utils.py
+++ b/azure/batch_extensions/_template_utils.py
@@ -59,7 +59,6 @@ def _validate_string(value, content):
     :param dict content: The template parameter definition.
     :returns: str
     """
-
     if value is None and content['defaultValue'] != "":
         raise TypeError("String value must be provided")
 


### PR DESCRIPTION
This prevent use of optional parameters. Original problem from https://github.com/Azure/BatchLabs/issues/1082