### PR TITLE
Update Batch Extentions - Bulk Task Add

### DIFF
--- a/azure/batch_extensions/batch_extensions_client.py
+++ b/azure/batch_extensions/batch_extensions_client.py
@@ -65,7 +65,6 @@ class BatchExtensionsClient(BatchServiceClient):
         self._resolved_storage_client = storage_client
         self._subscription = subscription_id
 
-        self.threads = None
         self.batch_account = batch_account
         self.resource_group = resource_group
 


### PR DESCRIPTION
Updated the bulk task add behavior of batch extensions - task operations to catch errors caused by chunks being too large and throwing RequestBodyTooLarge. 
Expected behavior on encountering this exception is to split the chunk into two and resubmitting. This is done recursively and is done until either success or the chunk is of size 1 in which case it can not be split anymore and the exception will be raised.

Added unit tests for multiple scenarios to ensure all tasks are chunked and the expected exception behavior is reached.  Additionally updated the multi/single threading chunking code to allow for greater flexibility and allow to better handle other failures.
