### PR TITLE
Align to Python SDK for shared models

### DIFF
--- a/azext/batch/_template_utils.py
+++ b/azext/batch/_template_utils.py
@@ -923,7 +923,8 @@ def construct_setup_task(existing_task, command_info, os_flavor):
     """
     if existing_task:
         result = dict(existing_task.__dict__)
-
+        if 'additional_properties' in result:
+            del result['additional_properties']
     else:
         result = {}
     commands = []

--- a/azext/batch/models/auto_pool_specification.py
+++ b/azext/batch/models/auto_pool_specification.py
@@ -52,6 +52,7 @@ class AutoPoolSpecification(Model):
     }
 
     def __init__(self, pool_lifetime_option, auto_pool_id_prefix=None, keep_alive=None, pool=None):
+        super(AutoPoolSpecification, self).__init__()
         self.auto_pool_id_prefix = auto_pool_id_prefix
         self.pool_lifetime_option = pool_lifetime_option
         self.keep_alive = keep_alive

--- a/azext/batch/models/job_manager_task.py
+++ b/azext/batch/models/job_manager_task.py
@@ -153,6 +153,7 @@ class JobManagerTask(Model):
                  output_files=None, environment_settings=None, constraints=None, kill_job_on_completion=None,
                  user_identity=None, run_exclusive=None, application_package_references=None,
                  authentication_token_settings=None, allow_low_priority_node=None):
+        super(JobManagerTask, self).__init__()
         self.id = id
         self.display_name = display_name
         self.command_line = command_line

--- a/azext/batch/models/job_preparation_task.py
+++ b/azext/batch/models/job_preparation_task.py
@@ -117,6 +117,7 @@ class JobPreparationTask(Model):
     def __init__(self, command_line, id=None, container_settings=None, resource_files=None,
                  environment_settings=None, constraints=None, wait_for_success=None, user_identity=None,
                  rerun_on_node_reboot_after_success=None):
+        super(JobPreparationTask, self).__init__()
         self.id = id
         self.command_line = command_line
         self.container_settings = container_settings

--- a/azext/batch/models/job_release_task.py
+++ b/azext/batch/models/job_release_task.py
@@ -101,6 +101,7 @@ class JobReleaseTask(Model):
 
     def __init__(self, command_line, id=None, container_settings=None, resource_files=None,
                  environment_settings=None, max_wall_clock_time=None, retention_time=None, user_identity=None):
+        super(JobReleaseTask, self).__init__()
         self.id = id
         self.command_line = command_line
         self.container_settings = container_settings

--- a/azext/batch/models/multi_instance_settings.py
+++ b/azext/batch/models/multi_instance_settings.py
@@ -42,6 +42,7 @@ class MultiInstanceSettings(Model):
     }
 
     def __init__(self, coordination_command_line, number_of_instances=None, common_resource_files=None):
+        super(MultiInstanceSettings, self).__init__()
         self.number_of_instances = number_of_instances
         self.coordination_command_line = coordination_command_line
         self.common_resource_files = common_resource_files

--- a/azext/batch/models/output_file.py
+++ b/azext/batch/models/output_file.py
@@ -50,6 +50,7 @@ class OutputFile(Model):
     }
 
     def __init__(self, file_pattern, destination, upload_options):
+        super(OutputFile, self).__init__()
         self.file_pattern = file_pattern
         self.destination = destination
         self.upload_options = upload_options

--- a/azext/batch/models/start_task.py
+++ b/azext/batch/models/start_task.py
@@ -78,6 +78,7 @@ class StartTask(Model):
 
     def __init__(self, command_line, container_settings=None, resource_files=None, environment_settings=None,
                  user_identity=None, max_task_retry_count=None, wait_for_success=None):
+        super(StartTask, self).__init__()
         self.command_line = command_line
         self.container_settings = container_settings
         self.resource_files = resource_files


### PR DESCRIPTION
Updated models that are shared between Python SDK and Python Extensions SDK, to align to the root SDK's practice of calling the super's init function.  

Updated a section of code which converted and object => dict => object to remove the 'additional_properties' attribute added by msrest serialization (as it will be re-added)