### PR TITLE
Update edge build installation to solve corruption issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,4 @@ setuptools==30.4.0
 six==1.10.0
 tabulate==0.7.5
 vcrpy==1.10.3
-azure-cli>=2.0.46,<2.1
 azure-storage-blob==1.1.0

--- a/scripts/dev_setup.py
+++ b/scripts/dev_setup.py
@@ -27,11 +27,11 @@ print('Running dev setup...')
 print(os.environ)
 print('Root directory \'{}\'\n'.format(root_dir))
 
-# install to edge build of azure-cli
-exec_command('pip install --upgrade --pre azure-cli --extra-index-url https://azurecliprod.blob.core.windows.net/edge --no-cache-dir')
-
 # install general requirements
 exec_command('pip install -r requirements.txt')
+
+# install to edge build of azure-cli
+exec_command('pip install --pre azure-cli --extra-index-url https://azurecliprod.blob.core.windows.net/edge --no-cache-dir')
 
 # upgrade to latest azure-batch
 exec_command('pip install --upgrade azure-batch')

--- a/scripts/dev_setup.py
+++ b/scripts/dev_setup.py
@@ -27,11 +27,11 @@ print('Running dev setup...')
 print(os.environ)
 print('Root directory \'{}\'\n'.format(root_dir))
 
-# install general requirements and azure-cli
-exec_command('pip install -r requirements.txt')
-
-# upgrade to edge build of azure-cli
+# install to edge build of azure-cli
 exec_command('pip install --upgrade --pre azure-cli --extra-index-url https://azurecliprod.blob.core.windows.net/edge --no-cache-dir')
+
+# install general requirements
+exec_command('pip install -r requirements.txt')
 
 # upgrade to latest azure-batch
 exec_command('pip install --upgrade azure-batch')


### PR DESCRIPTION
Update when we install the edge build (before install of cli) to hopefully solve corruption issue.  Edge build version should be strictly greater than the released version so should work.