### PR TITLE
CLI Extension Bug when executing normal operations

### DIFF
--- a/batch-cli-extensions/HISTORY.rst
+++ b/batch-cli-extensions/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+3.0.2 (2019-02-26)
+------------------
+
+* Fix bug when using extension to create a pool through normal CLI behavior
+
 3.0.1 (2019-02-04)
 ------------------
 

--- a/batch-cli-extensions/azext_batch/custom.py
+++ b/batch-cli-extensions/azext_batch/custom.py
@@ -56,7 +56,7 @@ def create_pool(client, template=None, parameters=None, json_file=None, id=None,
         if not id:
             raise ValueError('Please supply template, json_file, or id')
 
-        pool = PoolAddParameter(id, vm_size=vm_size)
+        pool = PoolAddParameter(id=id, vm_size=vm_size)
         if auto_scale_formula:
             pool.auto_scale_formula = auto_scale_formula
             pool.enable_auto_scale = True

--- a/batch-cli-extensions/azext_batch/custom.py
+++ b/batch-cli-extensions/azext_batch/custom.py
@@ -153,7 +153,7 @@ def create_job(client, template=None, parameters=None, json_file=None, id=None, 
             raise ValueError('Please supply template, json_file, or id')
 
         pool = PoolInformation(pool_id=pool_id)
-        job = JobAddParameter(id, pool, priority=priority)
+        job = JobAddParameter(id=id, pool_info=pool, priority=priority)
         job.uses_task_dependencies = uses_task_dependencies
         if job_max_wall_clock_time is not None or job_max_task_retry_count is not None:
             constraints = JobConstraints(max_wall_clock_time=job_max_wall_clock_time,

--- a/batch-cli-extensions/azext_batch/version.py
+++ b/batch-cli-extensions/azext_batch/version.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-VERSION = "3.0.1"
+VERSION = "3.0.2"


### PR DESCRIPTION
Fix bug when using extension to create a pool through normal CLI behavior.

This code path is only hit when creating a normal pool (ie no templates/json)