### PR TITLE
Remove azure.storage.blob in import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: python
 python:
-- '2.7'
-- '3.5'
 - '3.6'
 env:
 - AZURE_EXTENSION_DIR=./.azure/devcliextensions

--- a/azext/batch/_file_utils.py
+++ b/azext/batch/_file_utils.py
@@ -15,7 +15,7 @@ import pathlib
 from six.moves.urllib.parse import urlsplit  # pylint: disable=import-error,relative-import
 from six.moves.urllib.parse import quote  # pylint: disable=import-error,no-name-in-module,relative-import
 
-from azure.storage.blob import BlobPermissions, BlockBlobService
+from azure.multiapi.storage.v2018_11_09.blob import BlobPermissions, BlockBlobService
 from . import models
 
 def construct_sas_url(blob, uri):

--- a/azext/batch/batch_extensions_client.py
+++ b/azext/batch/batch_extensions_client.py
@@ -11,7 +11,7 @@ from msrest import Serializer, Deserializer
 from azure.batch import BatchServiceClient
 from azure.mgmt.batch import BatchManagementClient
 from azure.mgmt.storage import StorageManagementClient
-from azure.storage.blob import BlockBlobService
+from azure.multiapi.storage.v2018_11_09.blob import BlockBlobService
 from azure.common.credentials import get_cli_profile
 
 from .version import VERSION

--- a/azext/batch/operations/file_operations.py
+++ b/azext/batch/operations/file_operations.py
@@ -9,7 +9,7 @@ import errno
 import os
 
 from azure.batch.operations._file_operations import FileOperations
-from azure.storage.blob.models import Include
+from azure.multiapi.storage.v2018_11_09.blob.models import Include
 
 from .. import _file_utils as file_utils
 

--- a/batch-cli-extensions/azext_batch/version.py
+++ b/batch-cli-extensions/azext_batch/version.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-VERSION = "5.0.1"
+VERSION = "5.0.2"

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -13,8 +13,8 @@ from mock import patch, Mock, MagicMock
 from msrest import Serializer, Deserializer
 from azure.batch.operations._task_operations import TaskOperations
 from azure.batch.operations._pool_operations import PoolOperations
-from azure.storage.common import CloudStorageAccount
-from azure.storage.blob.blockblobservice import BlockBlobService
+from azure.multiapi.storage.v2018_11_09.common import CloudStorageAccount
+from azure.multiapi.storage.v2018_11_09.blob.blockblobservice import BlockBlobService
 from azure.batch.batch_auth import SharedKeyCredentials
 from azure.batch.models import BatchErrorException, BatchError, TaskAddCollectionResult, TaskAddResult, TaskAddStatus
 from azure.batch import models as base_sdk_models

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -13,8 +13,8 @@ import azure.batch.batch_auth as batchauth
 import azext.batch as batch
 from tests.vcr_test_base import VCRTestBase
 from azure.common import AzureMissingResourceHttpError
-from azure.storage.common import CloudStorageAccount
-from azure.storage.blob import BlobPermissions
+from azure.multiapi.storage.v2018_11_09.common import CloudStorageAccount
+from azure.multiapi.storage.v2018_11_09.blob import BlobPermissions
 
 class TestFileUpload(VCRTestBase):
     def __init__(self, test_method):


### PR DESCRIPTION
Because there is breaking change in azure-storage-blob and CLI core module will remove the dependency for azure-storage-blob, batch-cli-extensions is using this package with requirement.

If we don't change this part in the extension, CLI cannot remove the package dependency as shown [here](https://github.com/Azure/azure-cli/pull/13490).